### PR TITLE
Solve loss of TLS 1.0 support by patching old version of PHPMailer

### DIFF
--- a/includes/smtp.transport.inc
+++ b/includes/smtp.transport.inc
@@ -198,12 +198,19 @@ class SMTP {
       return FALSE;
     }
 
-    // Begin encrypted connection
-    if (!stream_socket_enable_crypto($this->smtp_conn, TRUE, STREAM_CRYPTO_METHOD_TLS_CLIENT)) {
-      return FALSE;
+    // Allow the best TLS version(s) we can
+    $crypto_method = STREAM_CRYPTO_METHOD_TLS_CLIENT;
+    // PHP 5.6.7 dropped inclusion of TLS 1.1 and 1.2 in STREAM_CRYPTO_METHOD_TLS_CLIENT
+    // so add them back in manually if we can
+    if (defined('STREAM_CRYPTO_METHOD_TLSv1_2_CLIENT')) {
+      $crypto_method |= STREAM_CRYPTO_METHOD_TLSv1_2_CLIENT;
+      $crypto_method |= STREAM_CRYPTO_METHOD_TLSv1_1_CLIENT;
     }
 
-    return TRUE;
+    // Begin encrypted connection
+    $crypto_ok = stream_socket_enable_crypto($this->smtp_conn, TRUE, $crypto_method);
+
+    return (bool) $crypto_ok;
   }
 
   /**


### PR DESCRIPTION
Applying https://www.drupal.org/files/issues/2018-07-26/smtp-tlsv1_1-2983132-17.patch

Addresses #9.